### PR TITLE
The times are incorrectly being shown as Hour:hour:Second - this is fixed in this commit.

### DIFF
--- a/convert
+++ b/convert
@@ -31,7 +31,7 @@ end
 
 @output.sort_by(&:timestamp).each do |line|
   if line.sender
-    print "[" + line.timestamp.strftime("%H:%I:%S") + "] #{line.sender}: "
+    print "[" + line.timestamp.strftime("%H:%M:%S") + "] #{line.sender}: "
   else
     print " ** "
   end


### PR DESCRIPTION
When converting, the script would show the time incorrectly.

For example:

"2013-02-12 17:11:14 -0000"

was being converted to

"17:05:14"

because I is 12 hour clock Hours.
