### PR TITLE
Change shebang line from ruby-local-exec to just ruby

### DIFF
--- a/convert
+++ b/convert
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby-local-exec
+#!/usr/bin/env ruby
 
 require 'rubygems'
 require 'bundler/setup'


### PR DESCRIPTION
ruby-local-exec is deprecated. See the following link for details:
  https://github.com/sstephenson/rbenv/wiki/ruby-local-exec
